### PR TITLE
use de/encodeURIComponent instead of de/encodeURI

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -41,6 +41,8 @@ function get(resourceId, qs, cb) {
   // We do not use url.resolve becuase if the resourceId contains a leading slash,
   // we would end up with an incorrect url.
   var requestUrl = this.resourcePath + '/' + encodeURIComponent(resourceId)
+  console.log('====================== ', requestUrl)
+  console.log('==========uri', encodeUri(requestUrl))
   return this.client.request({method: 'GET', uri: encodeUri(requestUrl), qs: qs}, cb)
 }
 
@@ -50,9 +52,12 @@ function encodeUri(uri) {
   // Only encode string uris, if the uri is a parsed uri object, we do nothing.
   if (typeof uri === 'string') {
     var parts = urlUtil.parse(uri)
+    console.log('=============parts', parts)
     if (parts.pathname) {
       // Prevent double encoding by calling decodeURI first
       parts.pathname = encodeURI(decodeURI(parts.pathname))
+      console.log('================parts.pathname', parts.pathname)
+      console.log('=============parts', parts)
       uri = urlUtil.format(parts)
     }
   }

--- a/Client.js
+++ b/Client.js
@@ -40,7 +40,7 @@ function get(resourceId, qs, cb) {
   }
   // We do not use url.resolve becuase if the resourceId contains a leading slash,
   // we would end up with an incorrect url.
-  var requestUrl = this.resourcePath + '/' + encodeUriComponent(resourceId)
+  var requestUrl = this.resourcePath + '/' + encodeURIComponent(resourceId)
   return this.client.request({method: 'GET', uri: encodeUri(requestUrl), qs: qs}, cb)
 }
 

--- a/Client.js
+++ b/Client.js
@@ -40,7 +40,7 @@ function get(resourceId, qs, cb) {
   }
   // We do not use url.resolve becuase if the resourceId contains a leading slash,
   // we would end up with an incorrect url.
-  var requestUrl = this.resourcePath + '/' + resourceId
+  var requestUrl = this.resourcePath + '/' + encodeUriComponent(resourceId)
   return this.client.request({method: 'GET', uri: encodeUri(requestUrl), qs: qs}, cb)
 }
 

--- a/Client.js
+++ b/Client.js
@@ -1,5 +1,4 @@
 var request = require('request')
-var urlUtil = require('url')
 
 function Client(accessToken) {
   this.accessToken = accessToken
@@ -39,12 +38,12 @@ function get(resourceId, qs, cb) {
     qs = {}
   }
   
-  return this.client.request({method: 'GET', uri: encodeUri(this.resourcePath, resourceId), qs: qs}, cb)
+  return this.client.request({method: 'GET', uri: getUrlForResource(this.resourcePath, resourceId), qs: qs}, cb)
 }
 
 // The request library does not correctly encode non-ascii characters when provided
 // in the uri. See: https://github.com/request/request/pull/2210 for more info.
-function encodeUri(path, id) {
+function getUrlForResource(path, id) {
   // Prevent double encoding by calling decodeURI first
   resourceId = encodeURIComponent(decodeURIComponent(id));
   

--- a/Client.js
+++ b/Client.js
@@ -38,30 +38,17 @@ function get(resourceId, qs, cb) {
     cb = qs
     qs = {}
   }
-  // We do not use url.resolve becuase if the resourceId contains a leading slash,
-  // we would end up with an incorrect url.
-  var requestUrl = this.resourcePath + '/' + encodeURIComponent(resourceId)
-  console.log('====================== ', requestUrl)
-  console.log('==========uri', encodeUri(requestUrl))
-  return this.client.request({method: 'GET', uri: encodeUri(requestUrl), qs: qs}, cb)
+  
+  return this.client.request({method: 'GET', uri: encodeUri(this.resourcePath, resourceId), qs: qs}, cb)
 }
 
 // The request library does not correctly encode non-ascii characters when provided
 // in the uri. See: https://github.com/request/request/pull/2210 for more info.
-function encodeUri(uri) {
-  // Only encode string uris, if the uri is a parsed uri object, we do nothing.
-  if (typeof uri === 'string') {
-    var parts = urlUtil.parse(uri)
-    console.log('=============parts', parts)
-    if (parts.pathname) {
-      // Prevent double encoding by calling decodeURI first
-      parts.pathname = encodeURI(decodeURI(parts.pathname))
-      console.log('================parts.pathname', parts.pathname)
-      console.log('=============parts', parts)
-      uri = urlUtil.format(parts)
-    }
-  }
-  return uri
+function encodeUri(path, id) {
+  // Prevent double encoding by calling decodeURI first
+  resourceId = encodeURIComponent(decodeURIComponent(id));
+  
+  return path + '/' + resourceId;
 }
 
 /*


### PR DESCRIPTION
- building names that contain `/` are causing [404 errors](https://app.datadoghq.com/apm/resource/taskqueue2-scheduling/task.run/fcf74e63e649dade?end=1620928253987&env=prod&event=AQAAAXlhOTEF4WoUlgAAAABBWGxoT1VZY0FBQVZONlU0M2xod0NDbEY&index=apm-search&paused=false&query=env%3Aprod%20service%3Ataskqueue2-scheduling%20operation_name%3Atask.run%20resource_name%3Acalendar-resources-get%20%40task.accountId%3Af773f08e-9d9d-4759-a68f-0a967737e2b3&spanID=7720450433772730264&spanViewType=metadata&start=1620924653987&traceID=4983723881071705169)
- able to reproduce this locally + put in a fix / validate in staging as well
![Screen Shot 2021-05-13 at 10 44 05 AM](https://user-images.githubusercontent.com/4452473/118165483-31389900-b3d9-11eb-9cf4-e933c8efed0a.png)
- validate that non-ascii characters still work as expected^


- [BE-312](https://leverapp.atlassian.net/browse/BE-312)